### PR TITLE
C64 theme for /api docs + site polish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ docs: prepare-web
 	cd contracts && fe doc -o ../web/static/api bundle
 	cd contracts && fe doc -o ../web/static/api static
 	sed -i 's/Fe Docs/Bountiful Docs/g; s/Fe Documentation/Bountiful Documentation/g' web/static/api/index.html
+	sed -i 's|<link rel="stylesheet" href="fe-highlight.css">|<link rel="stylesheet" href="fe-highlight.css">\n  <link rel="stylesheet" href="../css/api-theme.css">|' web/static/api/index.html
 
 # Remove all build artifacts
 clean:

--- a/web/static/css/api-theme.css
+++ b/web/static/css/api-theme.css
@@ -1,0 +1,165 @@
+/* Bountiful C64 theme for the generated /api docs.
+   Uses the theming knobs exposed by fe-web's styles.css — override the
+   CSS custom properties and you retheme the whole viewer. */
+
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Silkscreen:wght@400;700&display=swap');
+
+/* Apply C64 palette + pixel rendering in all modes.
+   Selectors mirror fe-web's so we win on specificity for dark mode. */
+:root,
+:root[data-theme="light"],
+:root[data-theme="dark"] {
+  /* Palette */
+  --bg: #40318D;
+  --bg-secondary: #2B1E5C;
+  --text: #DDD6F3;
+  --text-muted: #9E90D6;
+  --border: #7869C4;
+  --accent: #FFD866;
+  --accent-hover: #FFEF8F;
+  --text-accent: #FFD866;
+  --code-bg: #241750;
+
+  /* Highlight colors — tuned for the purple backdrop */
+  --hl-ref-bg: rgba(255, 216, 102, 0.10);
+  --hl-def-bg: rgba(255, 216, 102, 0.22);
+  --hl-def-underline: rgba(255, 216, 102, 0.55);
+  --target-bg: color-mix(in srgb, #FFD866 15%, #2B1E5C);
+
+  /* Root size: bump from the browser default 16px so everything rem-based
+   scales up together. Silkscreen at small rem values gets illegible. */
+}
+html { font-size: 18px; }
+:root, :root[data-theme="light"], :root[data-theme="dark"] {
+  /* Fonts — Silkscreen everywhere */
+  --fe-body-font: 'Silkscreen', 'Press Start 2P', monospace;
+  --fe-heading-font: 'Silkscreen', 'Press Start 2P', monospace;
+  --fe-mono-font: 'Silkscreen', 'Press Start 2P', monospace;
+  --fe-code-font: 'Silkscreen', 'Press Start 2P', monospace;
+
+  /* Pixel / retro rendering */
+  --fe-heading-weight: 400;
+  --fe-body-weight: 400;
+  --fe-sidebar-weight: 400;
+  --fe-current-weight: 400;
+  --fe-font-smoothing: none;
+  --fe-moz-font-smoothing: grayscale;
+  --fe-text-rendering: geometricPrecision;
+  --fe-letter-spacing: -0.02em;
+  /* Simulate bold via text-shadow — widens strokes without changing advance.
+     --fe-heading-text-shadow applies to h1-h6, --fe-emphasis-text-shadow
+     applies to the current sidebar item. */
+  --fe-heading-text-shadow: 1px 0 0 currentColor;
+  --fe-emphasis-text-shadow: 1px 0 0 currentColor;
+
+  /* Let content fill; 900px cap leaves empty space with pixel sidebar */
+  --fe-content-max-width: none;
+
+  /* Silkscreen is wider per-glyph than proportional sans, so give the
+     sidebar a bit more room than the 25vw default. 30vw keeps the
+     sidebar from dominating while still fitting most symbols; items
+     beyond that width truncate with `…` via the rule below. */
+  --fe-sidebar-max-width: 30vw;
+
+  /* fe-code-block shadow-DOM theming (inherits custom props into shadow) */
+  --fe-code-bg: #241750;
+  --fe-code-border: #7869C4;
+  --fe-code-text: #DDD6F3;
+  --fe-code-line-number: #7869C4;
+  --fe-code-size: 0.9rem;
+  --fe-code-line-height: 1.6;
+  --fe-code-radius: 3px;
+
+  /* Syntax highlight palette */
+  --fe-hl-keyword: #FF79C6;
+  --fe-hl-type: #FFD866;
+  --fe-hl-type-interface: #F8C8DC;
+  --fe-hl-type-variant: #FFB86C;
+  --fe-hl-function: #8BE9FD;
+  --fe-hl-string: #A6E22E;
+  --fe-hl-number: #FFB86C;
+  --fe-hl-comment: #7869C4;
+  --fe-hl-operator: #DDD6F3;
+  --fe-hl-punctuation: #DDD6F3;
+}
+
+/* Match fe-web's dark-mode media-query selector so we win there too */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg: #40318D;
+    --bg-secondary: #2B1E5C;
+    --text: #DDD6F3;
+    --text-muted: #9E90D6;
+    --border: #7869C4;
+    --accent: #FFD866;
+    --accent-hover: #FFEF8F;
+    --text-accent: #FFD866;
+    --code-bg: #241750;
+    --hl-ref-bg: rgba(255, 216, 102, 0.10);
+    --hl-def-bg: rgba(255, 216, 102, 0.22);
+    --hl-def-underline: rgba(255, 216, 102, 0.55);
+    --target-bg: color-mix(in srgb, #FFD866 15%, #2B1E5C);
+  }
+}
+
+/* Bountiful-specific UI sugar that isn't covered by fe-web's knobs.
+   Keep this section thin — everything theme-parameterizable belongs above. */
+
+/* Explicit arrow marker for current sidebar item — a11y / colorblind-safe.
+   Every row reserves an invisible spacer so state changes don't reflow; the
+   current row just turns the glyph visible. */
+.fe-nav-items a::before,
+.fe-nav-mod-name a::before {
+  content: "▸";
+  display: inline-block;
+  color: transparent;
+  margin-right: 0.35em;
+  margin-left: -0.5em;
+  width: 0.7em;
+  flex-shrink: 0;
+}
+
+.fe-nav-items li.current > a::before,
+.fe-nav-mod-name.current > a::before {
+  color: var(--accent);
+}
+
+/* Pixel-style drop shadow on page h1 (additive to --fe-heading-text-shadow) */
+article h1,
+.item-header h1 {
+  color: var(--accent);
+  text-shadow:
+    1px 0 0 currentColor,
+    2px 2px 0 var(--bg-secondary);
+}
+
+article h2 {
+  color: var(--accent);
+  border-bottom: 2px solid var(--border);
+  padding-bottom: 0.25rem;
+}
+
+/* Member cards: CRT-phosphor inner glow */
+.member-item {
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--bg-secondary) 60%, var(--bg));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+/* Truncate long sidebar names with `…` instead of forcing the sidebar
+   to grow indefinitely. Silkscreen's wide glyphs mean some `test_*`
+   names exceed 50vw — truncation keeps the sidebar usable; horizontal
+   scroll inside the sidebar (overflow-x: auto from fe-web) remains as
+   the fallback if the user wants to see the full name. */
+.fe-nav-items a {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.fe-nav-items a > :last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}

--- a/web/static/css/c64.css
+++ b/web/static/css/c64.css
@@ -5,13 +5,13 @@
   --c64-text: #DDD6F3;
   --c64-white: #FFFFFF;
   --c64-dark: #2B1E5C;
-  --font: 'Press Start 2P', monospace;
+  --font: 'Silkscreen', monospace;
 
   /* Fe web component theming */
   --fe-code-bg: #2B1E5C;
   --fe-code-border: #7869C4;
   --fe-code-text: #C8BFE7;
-  --fe-code-font: 'Press Start 2P', monospace;
+  --fe-code-font: 'Silkscreen', monospace;
   --fe-code-size: 0.6rem;
   --fe-code-line-height: 1.8;
   --fe-code-line-number: #7869C4;
@@ -34,7 +34,7 @@
 
 /* ── BASE ── */
 html {
-  font-size: 14px;
+  font-size: 18px;
 }
 
 body {
@@ -42,8 +42,35 @@ body {
   font-family: var(--font);
   color: var(--c64-text);
   line-height: 1.8;
+  letter-spacing: -0.06em;
   height: 100vh;
   overflow: hidden;
+  -webkit-font-smoothing: none;
+  -moz-osx-font-smoothing: grayscale;
+  font-smooth: never;
+  text-rendering: geometricPrecision;
+  /* Blend scrollbars with the C64 palette */
+  scrollbar-width: thin;
+  scrollbar-color: var(--c64-border) var(--c64-bg);
+}
+
+/* Webkit scrollbars — match the CRT palette */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-track {
+  background: var(--c64-bg);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--c64-border);
+  border-radius: 2px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--c64-text);
+}
+::-webkit-scrollbar-corner {
+  background: var(--c64-bg);
 }
 
 /* ── CRT BORDER / FRAME ── */
@@ -92,6 +119,7 @@ body {
 
 .c64-header .stars {
   color: var(--c64-white);
+  font-family: 'Press Start 2P', monospace;
   font-size: 1rem;
   margin-bottom: 4px;
 }
@@ -570,8 +598,8 @@ ol li::before {
   display: block;
 }
 
-/* ── RESPONSIVE: single column on small screens ── */
-@media (max-width: 768px) {
+/* ── RESPONSIVE: single column on narrow viewports ── */
+@media (max-width: 1024px) {
   body {
     height: auto;
     overflow: auto;
@@ -599,7 +627,7 @@ ol li::before {
   }
 
   html {
-    font-size: 12px;
+    font-size: 22px;
   }
 
   .puzzle-board {

--- a/web/static/css/c64.css
+++ b/web/static/css/c64.css
@@ -241,6 +241,13 @@ ol li::before {
   padding: 6px 8px;
   margin-bottom: 4px;
   border-left: 2px solid var(--c64-border);
+  --fe-code-border: transparent;
+  --fe-code-bg: transparent;
+}
+
+.doc-impl > fe-code-block {
+  --fe-code-border: transparent;
+  --fe-code-bg: transparent;
 }
 
 .doc-sig {
@@ -257,6 +264,12 @@ ol li::before {
 
 .doc-sig .sig-link:hover {
   text-decoration: underline;
+}
+
+/* Signature code blocks in source viewer should be compact */
+.doc-field fe-code-block,
+.doc-method fe-code-block {
+  --fe-code-size: 0.6rem;
 }
 
 .doc-desc {

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -7,7 +7,7 @@
   <meta name="description" content="{{ config.description }}">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Silkscreen:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ get_url(path='css/c64.css') }}">
   <style>
   /* fe-highlight.css — required for <fe-code-block> shadow DOM styling */

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -274,18 +274,6 @@
     document.body.removeChild(input);
   };
 
-  // Render a rich_signature array into an HTML string
-  function renderRichSig(parts) {
-    if (!parts) return '';
-    return parts.map(p => {
-      const escaped = p.text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-      if (p.link) {
-        return '<a href="#' + p.link + '" class="sig-link">' + escaped + '</a>';
-      }
-      return escaped;
-    }).join('');
-  }
-
   // Render fields and implementations below the code block
   function renderDocDetails(viewer, symbolPath) {
     const index = window.FE_DOC_INDEX;
@@ -302,9 +290,17 @@
       fields.forEach(f => {
         const div = document.createElement('div');
         div.className = 'doc-field';
-        const sig = f.rich_signature ? renderRichSig(f.rich_signature) : f.signature;
-        div.innerHTML = '<code class="doc-sig">' + sig + '</code>'
-          + (f.docs && f.docs.summary ? '<p class="doc-desc">' + f.docs.summary + '</p>' : '');
+        const cb = document.createElement('fe-code-block');
+        cb.setAttribute('lang', 'fe');
+        if (f.sig_scope) cb.setAttribute('data-scope', f.sig_scope);
+        cb.textContent = f.signature || f.name;
+        div.appendChild(cb);
+        if (f.docs && f.docs.summary) {
+          const p = document.createElement('p');
+          p.className = 'doc-desc';
+          p.textContent = f.docs.summary;
+          div.appendChild(p);
+        }
         section.appendChild(div);
       });
       viewer.appendChild(section);
@@ -316,15 +312,26 @@
       impls.forEach(impl => {
         const section = document.createElement('div');
         section.className = 'doc-impl';
-        const implSig = impl.rich_signature ? renderRichSig(impl.rich_signature) : impl.signature;
-        section.innerHTML = '<h3>&gt; <code class="doc-sig">' + implSig + '</code></h3>';
+        const implCb = document.createElement('fe-code-block');
+        implCb.setAttribute('lang', 'fe');
+        if (impl.sig_scope) implCb.setAttribute('data-scope', impl.sig_scope);
+        implCb.textContent = impl.signature || '';
+        section.appendChild(implCb);
 
         (impl.methods || []).forEach(m => {
           const div = document.createElement('div');
           div.className = 'doc-method';
-          const mSig = m.rich_signature ? renderRichSig(m.rich_signature) : m.signature;
-          div.innerHTML = '<code class="doc-sig">' + mSig + '</code>'
-            + (m.docs && m.docs.summary ? '<p class="doc-desc">' + m.docs.summary + '</p>' : '');
+          const mCb = document.createElement('fe-code-block');
+          mCb.setAttribute('lang', 'fe');
+          if (m.sig_scope) mCb.setAttribute('data-scope', m.sig_scope);
+          mCb.textContent = m.signature || m.name;
+          div.appendChild(mCb);
+          if (m.docs && m.docs.summary) {
+            const p = document.createElement('p');
+            p.className = 'doc-desc';
+            p.textContent = m.docs.summary;
+            div.appendChild(p);
+          }
           section.appendChild(div);
         });
 
@@ -334,7 +341,7 @@
   }
 
   // Show source for a given SCIP symbol in the viewer quadrant
-  function showSource(symbol, label) {
+  function showSource(symbol, label, pushHistory) {
     // Clear active button highlight (only relevant for contract table buttons)
     document.querySelectorAll('.source-btn').forEach(b => b.classList.remove('active'));
     const matchingBtn = document.querySelector('.source-btn[data-symbol="' + symbol + '"]');
@@ -358,6 +365,10 @@
         renderDocDetails(viewer, symbol);
       });
     }
+
+    if (pushHistory) {
+      history.pushState({ symbol: symbol, label: displayName }, '', '#src/' + symbol);
+    }
   }
 
   // Source viewer: show contract source in bottom-right quadrant
@@ -368,23 +379,27 @@
 
       const row = button.closest('tr');
       const name = row ? row.querySelector('td').textContent : symbol;
-      showSource(symbol, name);
+      showSource(symbol, name, true);
     });
   });
 
-  // Intercept symbol link clicks from within fe-code-block.
-  // The component sets location.hash = "#" + docPath when a symbol is clicked.
-  // The docPath is already the format fe-code-block expects as its symbol attribute.
-  window.addEventListener('hashchange', () => {
-    const docUrl = location.hash.replace(/^#/, '');
-    if (!docUrl) return;
-
-    history.replaceState(null, '', location.pathname);
+  // Intercept fe-navigate events from fe-code-block to keep navigation
+  // within the source viewer instead of navigating to /api/
+  document.addEventListener('fe-navigate', (e) => {
+    const docPath = e.detail && e.detail.docPath;
+    if (!docPath) return;
+    e.preventDefault();
     // Doc URLs have a kind suffix like /struct, /contract, /mod — strip it
-    // to get the path that fe-code-block and FE_DOC_INDEX use.
-    const symbolPath = docUrl.replace(/\/[^/]*$/, '');
+    const symbolPath = docPath.replace(/\/[^/]*$/, '');
     const name = symbolPath.split('::').pop();
-    showSource(symbolPath, name);
+    showSource(symbolPath, name, true);
+  });
+
+  // Handle back/forward navigation
+  window.addEventListener('popstate', (e) => {
+    if (e.state && e.state.symbol) {
+      showSource(e.state.symbol, e.state.label, false);
+    }
   });
 
   document.querySelectorAll('.copy-contract-btn').forEach((button) => {
@@ -441,8 +456,15 @@
     });
   });
 
-  // Pre-select Registry source on load
-  const registryBtn = document.querySelector('.source-btn[data-symbol="registry::registry::BountyRegistry"]');
-  if (registryBtn) registryBtn.click();
+  // Pre-select source on load: restore from hash or default to Registry
+  if (location.hash.startsWith('#src/')) {
+    const sym = decodeURIComponent(location.hash.slice(5));
+    const name = sym.split('::').pop();
+    showSource(sym, name, false);
+    history.replaceState({ symbol: sym, label: name }, '', location.hash);
+  } else {
+    showSource('registry::registry::BountyRegistry', 'REGISTRY', false);
+    history.replaceState({ symbol: 'registry::registry::BountyRegistry', label: 'REGISTRY' }, '', '#src/registry::registry::BountyRegistry');
+  }
 </script>
 {% endblock %}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -356,16 +356,6 @@
     codeBlock.setAttribute('line-numbers', '');
     viewer.appendChild(codeBlock);
 
-    // Render fields & implementations once doc index is available
-    if (window.FE_DOC_INDEX && window.FE_DOC_INDEX.items) {
-      renderDocDetails(viewer, symbol);
-    } else {
-      document.addEventListener('fe-web-ready', function onReady() {
-        document.removeEventListener('fe-web-ready', onReady);
-        renderDocDetails(viewer, symbol);
-      });
-    }
-
     if (pushHistory) {
       history.pushState({ symbol: symbol, label: displayName }, '', '#src/' + symbol);
     }
@@ -383,16 +373,14 @@
     });
   });
 
-  // Intercept fe-navigate events from fe-code-block to keep navigation
-  // within the source viewer instead of navigating to /api/
+  // Intercept fe-navigate events from fe-code-block and route symbol
+  // clicks to the full /api/ doc page in the same tab — source viewer
+  // is just a reading widget, the API docs are the destination.
   document.addEventListener('fe-navigate', (e) => {
     const docPath = e.detail && e.detail.docPath;
     if (!docPath) return;
     e.preventDefault();
-    // Doc URLs have a kind suffix like /struct, /contract, /mod — strip it
-    const symbolPath = docPath.replace(/\/[^/]*$/, '');
-    const name = symbolPath.split('::').pop();
-    showSource(symbolPath, name, true);
+    window.location.href = '/api/#' + docPath;
   });
 
   // Handle back/forward navigation


### PR DESCRIPTION
## Summary

- Generated `/api` docs now inherit the Bountiful C64 theme (purple palette, Silkscreen font) via a new `web/static/css/api-theme.css` that overrides the CSS custom properties fe-web exposes. `Makefile` injects the theme link into the generated `index.html`.
- c64.css: scrollbars blend with the CRT palette, responsive breakpoint bumped 768 to 1024px, mobile root font-size tuned for Silkscreen legibility.
- Source viewer on the landing page is just the code block now. Symbol clicks open the full `/api` doc page in the same tab rather than re-rendering a half-baked inline doc page.

## Test plan

- [ ] Check the homepage source viewer: click a symbol, should land on the matching `/api/#...` page
- [ ] `/api/` home loads with C64 palette and Silkscreen UI
- [ ] Sidebar current-item arrow marker renders; variant rows are clickable
- [ ] Responsive view collapses to single column on narrow viewport
- [ ] Scrollbars render with C64 palette (not default browser chrome)

Depends on the matching fe branch (`msg-doc-overhaul`) once that lands upstream.